### PR TITLE
Multiple styles

### DIFF
--- a/FashionTests/iOS/StylesheetTests.swift
+++ b/FashionTests/iOS/StylesheetTests.swift
@@ -25,6 +25,25 @@ class StylesheetTests: XCTestCase {
     XCTAssertNotNil(Stylist.master.styles[style])
   }
 
+  func testRegisterMultiple() {
+    stylesheet.register(style) { (button: UIButton) in
+      button.backgroundColor = UIColor.red
+    }
+
+    stylesheet.register(style) { (button: UIButton) in
+      button.tintColor = UIColor.red
+    }
+
+    let button = UIButton()
+    button.backgroundColor = .blue
+    button.tintColor = .blue
+    button.stylize(style)
+
+    // It applies multiple register closures
+    XCTAssertTrue(button.backgroundColor == .red)
+    XCTAssertTrue(button.tintColor == .red)
+  }
+
   func testUnregister() {
     stylesheet.register(style, stylization: { (button: UIButton) in
       button.backgroundColor = UIColor.red
@@ -58,4 +77,28 @@ class StylesheetTests: XCTestCase {
     // It unregisters shared stylization closure for the specified type
     XCTAssertNil(Stylist.master.sharedStyles["UIButton"])
   }
+
+  func testClear() {
+    stylesheet.share { (button: UILabel) in
+      button.backgroundColor = UIColor.red
+    }
+
+    stylesheet.register(style) { (button: UIButton) in
+      button.backgroundColor = UIColor.red
+    }
+
+    Stylist.master.clear()
+    let button = UIButton()
+    button.backgroundColor = .blue
+    button.stylize(style)
+    let label = UILabel()
+    label.backgroundColor = .blue
+    label.stylize(style)
+
+    // It clears registered and shared styles
+    XCTAssertFalse(button.backgroundColor == .red)
+    XCTAssertFalse(label.backgroundColor == .red)
+    XCTAssertTrue(Stylist.master.styles[style] == nil || Stylist.master.styles[style]?.count == 0)
+  }
+
 }

--- a/Sources/Shared/Style.swift
+++ b/Sources/Shared/Style.swift
@@ -16,7 +16,7 @@ final class Style<T: Styleable> {
 
   - Parameter model: `Styleable` view/model.
   */
-  func applyTo(_ model: Styleable) -> Void {
+  func applyTo(_ model: Styleable) {
     guard let model = model as? T else {
       return
     }

--- a/Sources/Shared/Stylist.swift
+++ b/Sources/Shared/Stylist.swift
@@ -8,7 +8,7 @@ public final class Stylist {
   typealias Stylization = (_ model: Styleable) -> Void
 
   var sharedStyles: [String: Stylization] = [:]
-  var styles: [String: Stylization] = [:]
+  var styles: [String: [Stylization]] = [:]
 
   // MARK: - Initialization
 
@@ -35,9 +35,10 @@ public final class Stylist {
    - Parameter model: `Styleable` view/model.
    */
   func apply(_ style: String, model: Styleable) -> Void {
-    guard let style = styles[style] else { return }
-
-    style(model)
+    guard let styles = self.styles[style] else { return }
+    for style in styles {
+        style(model)
+    }
   }
 
   /**
@@ -80,7 +81,10 @@ extension Stylist: StyleManaging {
   public func register<T: Styleable>(_ name: StringConvertible, stylization: @escaping (T) -> Void) {
     let style = Style(process: stylization)
 
-    styles[name.string] = style.applyTo
+    if styles[name.string] == nil {
+      styles[name.string] = []
+    }
+    styles[name.string]!.append(style.applyTo)
   }
 
   /**

--- a/Sources/Shared/Stylist.swift
+++ b/Sources/Shared/Stylist.swift
@@ -22,7 +22,7 @@ public final class Stylist {
   - Parameter styles: Names of the style you want to apply in the specified order.
   - Parameter model: `Styleable` view/model.
   */
-  func apply(_ styles: [String], model: Styleable) -> Void {
+  func apply(_ styles: [String], model: Styleable) {
     for style in styles {
       apply(style, model: model)
     }
@@ -34,7 +34,7 @@ public final class Stylist {
    - Parameter style: Name of the style you want to apply.
    - Parameter model: `Styleable` view/model.
    */
-  func apply(_ style: String, model: Styleable) -> Void {
+  func apply(_ style: String, model: Styleable) {
     guard let styles = self.styles[style] else { return }
     for style in styles {
         style(model)

--- a/Sources/Shared/Stylist.swift
+++ b/Sources/Shared/Stylist.swift
@@ -117,4 +117,12 @@ extension Stylist: StyleManaging {
   public func unshare<T: Styleable>(_ type: T.Type) {
     sharedStyles.removeValue(forKey: String(describing: type))
   }
+
+  /**
+   Clears all the styles
+  */
+  public func clear() {
+    sharedStyles = [:]
+    styles = [:]
+  }
 }


### PR DESCRIPTION
This allows you to register multiple styles for the same strings. This is useful when grouping different styles ie (all these get shadows), and then setting other properties in other closures.

This pull request also allows you to clear styles, and fixes some swift warnings