### PR TITLE
Lower tvOS minimum version and fix tests

### DIFF
--- a/Fashion.podspec
+++ b/Fashion.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '9.2'
+  s.tvos.deployment_target = '9.0'
 
   s.requires_arc = true
   s.ios.source_files = 'Sources/{iOS,Shared}/**/*'

--- a/Fashion.xcodeproj/xcshareddata/xcschemes/Fashion-tvOS.xcscheme
+++ b/Fashion.xcodeproj/xcshareddata/xcschemes/Fashion-tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D270E8FC1E0062C3008E7C5F"
+               BuildableName = "Fashion.framework"
+               BlueprintName = "Fashion-tvOS"
+               ReferencedContainer = "container:Fashion.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D270E9041E0062C3008E7C5F"
+               BuildableName = "Fashion-tvOSTests.xctest"
+               BlueprintName = "Fashion-tvOSTests"
+               ReferencedContainer = "container:Fashion.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D270E8FC1E0062C3008E7C5F"
+            BuildableName = "Fashion.framework"
+            BlueprintName = "Fashion-tvOS"
+            ReferencedContainer = "container:Fashion.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D270E8FC1E0062C3008E7C5F"
+            BuildableName = "Fashion.framework"
+            BlueprintName = "Fashion-tvOS"
+            ReferencedContainer = "container:Fashion.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D270E8FC1E0062C3008E7C5F"
+            BuildableName = "Fashion.framework"
+            BlueprintName = "Fashion-tvOS"
+            ReferencedContainer = "container:Fashion.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
There is no reason this minimum tvOS version has to be so high, as it restricts some codebases