### PR TITLE
fix(iOS) Address Xcode 13 issue: Swift libraries may fail to build for iOS targets that use armv7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Fashion",
-    platforms: [.iOS(.v9), .tvOS(.v9), .macOS(.v10_12)],
+    platforms: [.iOS(.v12), .tvOS(.v9), .macOS(.v10_12)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
This PR address an xcode 13 know issue. See [release notes for Xcode 13](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes)

> Swift libraries may fail to build for iOS targets that use armv7. (74120874) Workaround: Increase the platform dependency of the package to v12 or later.