### PR TITLE
Fix Swift 5.9 warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Carthage
 
 # SPM
 .build/
+.swiftpm/

--- a/Sources/Mac/NSView+Styleable.swift
+++ b/Sources/Mac/NSView+Styleable.swift
@@ -5,7 +5,7 @@ extension NSView: Styleable {}
 
 public extension NSView {
     private struct AssociatedKeys {
-        static var Style = "fashion_StyleAssociatedKey"
+        static var Style: Void?
     }
 
     /**
@@ -33,7 +33,9 @@ public extension NSView {
      */
     @IBInspectable var styles: String? {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.Style) as? String
+            withUnsafePointer(to: &AssociatedKeys.Style) {
+                return objc_getAssociatedObject(self, $0) as? String
+            }
         }
         set (newValue) {
             objc_setAssociatedObject(

--- a/Sources/iOS/UIView+SharedStyles.swift
+++ b/Sources/iOS/UIView+SharedStyles.swift
@@ -47,7 +47,9 @@ extension UIView {
 
   private var stylesApplied: Bool? {
     get {
-      return objc_getAssociatedObject(self, &AssociatedKeys.stylesApplied) as? Bool
+      withUnsafePointer(to: &AssociatedKeys.stylesApplied) {
+        objc_getAssociatedObject(self, $0) as? Bool
+      }
     }
     set (newValue) {
       objc_setAssociatedObject(

--- a/Sources/iOS/UIView+SharedStyles.swift
+++ b/Sources/iOS/UIView+SharedStyles.swift
@@ -3,7 +3,7 @@ import UIKit
 
 extension UIView {
   private struct AssociatedKeys {
-    static var stylesApplied = "fashion_StylesAppliedAssociatedKey"
+    static var stylesApplied: Void?
   }
 
   // MARK: - Method Swizzling

--- a/Sources/iOS/UIView+Styleable.swift
+++ b/Sources/iOS/UIView+Styleable.swift
@@ -50,7 +50,9 @@ extension UIView {
    */
   @IBInspectable public var styles: String? {
     get {
-      return objc_getAssociatedObject(self, &AssociatedKeys.Style) as? String
+      withUnsafePointer(to: &AssociatedKeys.Style) {
+        objc_getAssociatedObject(self, $0) as? String
+      }
     }
     set (newValue) {
       objc_setAssociatedObject(

--- a/Sources/iOS/UIView+Styleable.swift
+++ b/Sources/iOS/UIView+Styleable.swift
@@ -3,7 +3,7 @@ import UIKit
 
 extension UIView {
   private struct AssociatedKeys {
-    static var Style = "fashion_StyleAssociatedKey"
+    static var Style: Void?
   }
 
   public convenience init(frame: CGRect = CGRect.zero, styles: [StringConvertible]) {


### PR DESCRIPTION
Hello.
Thank you for Fashion.
Fix Swift 5.9 warnings (based on [this proposal](https://github.com/atrick/swift-evolution/blob/diagnose-implicit-raw-bitwise/proposals/nnnn-implicit-raw-bitwise-conversion.md#associated-object-string-keys)).